### PR TITLE
Fix: event.keyCode or event.charCode is used to examine pressed key

### DIFF
--- a/js/bootstrap-spinedit.js
+++ b/js/bootstrap-spinedit.js
@@ -137,20 +137,23 @@ $(function () {
         },
 
         _keypress: function (event) {
+            
+            var pressedKey = event.keyCode || event.charCode;
+            
             // Allow: -
-            if (event.keyCode == 45) {
+            if (pressedKey == 45) {
                 return;
             }
             // Allow decimal separator (.)
-            if (this.numberOfDecimals > 0 && event.keyCode == 46) {
+            if (this.numberOfDecimals > 0 && pressedKey == 46) {
                 return;
             }
             // Ensure that it is a number and stop the keypress
             var a = [];
             for (var i = 48; i < 58; i++)
                 a.push(i);
-            var k = event.keyCode;
-            if (!(a.indexOf(k) >= 0))
+
+            if (!(a.indexOf(pressedKey) >= 0))
                 event.preventDefault();
         },
 


### PR DESCRIPTION
In FF one is not able to type in a spinedit field. That's because keyCode is not populated. This fix assigns either event.keyCode or event.charCode to the pressedKey variable to ensure the correct behavior with different browsers.
